### PR TITLE
Add basic dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:22-alpine
+
+COPY . /app
+WORKDIR /app
+RUN npm install
+RUN npm run build
+
+CMD ["npm", "run", "start"]


### PR DESCRIPTION
I added a basic Dockerfile to make slightly easier for users to install or run on an environment without Node.

I can add a workflow to automatically build it and publish to Github's container registry so that users could run it with a single command, if that's something you're interested in.