### PR TITLE
Prevent message submission on on IME Enter confirmation

### DIFF
--- a/src/components/playground/ChatArea/ChatInput/ChatInput.tsx
+++ b/src/components/playground/ChatArea/ChatInput/ChatInput.tsx
@@ -39,7 +39,7 @@ const ChatInput = () => {
         value={inputMessage}
         onChange={(e) => setInputMessage(e.target.value)}
         onKeyDown={(e) => {
-          if (e.key === 'Enter' && !e.shiftKey && !isStreaming) {
+          if (e.key === 'Enter' && !e.nativeEvent.isComposing && !e.shiftKey && !isStreaming) {
             e.preventDefault()
             handleSubmit()
           }

--- a/src/components/playground/ChatArea/ChatInput/ChatInput.tsx
+++ b/src/components/playground/ChatArea/ChatInput/ChatInput.tsx
@@ -39,7 +39,12 @@ const ChatInput = () => {
         value={inputMessage}
         onChange={(e) => setInputMessage(e.target.value)}
         onKeyDown={(e) => {
-          if (e.key === 'Enter' && !e.nativeEvent.isComposing && !e.shiftKey && !isStreaming) {
+          if (
+            e.key === 'Enter' &&
+            !e.nativeEvent.isComposing &&
+            !e.shiftKey &&
+            !isStreaming
+          ) {
             e.preventDefault()
             handleSubmit()
           }


### PR DESCRIPTION
fixes a bug where pressing the Enter key while confirming an IME composition (e.g., Japanese, Chinese input) would unintentionally trigger message submission.