### PR TITLE
Add Recharts data visualization for agent responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-markdown": "^9.0.3",
+    "recharts": "^2.15.0",
     "rehype-raw": "^7.0.0",
     "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       react-markdown:
         specifier: ^9.0.3
         version: 9.0.3(@types/react@19.0.8)(react@18.3.1)
+      recharts:
+        specifier: ^2.15.0
+        version: 2.15.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       rehype-raw:
         specifier: ^7.0.0
         version: 7.0.0
@@ -120,6 +123,10 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@babel/runtime@7.28.4':
+    resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
+    engines: {node: '>=6.9.0'}
 
   '@emnapi/runtime@1.3.1':
     resolution: {integrity: sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==}
@@ -693,6 +700,33 @@ packages:
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.7':
+    resolution: {integrity: sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
@@ -1001,6 +1035,50 @@ packages:
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.0:
+    resolution: {integrity: sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
@@ -1035,6 +1113,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   decode-named-character-reference@1.0.2:
     resolution: {integrity: sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==}
@@ -1073,6 +1154,9 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
+
+  dom-helpers@5.2.1:
+    resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -1253,11 +1337,18 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-equals@5.3.4:
+    resolution: {integrity: sha512-d+yU9iNQbbC098NOuMlAIth/g+owbpX/uuOkH/DQcC2fMMyjOlX292Op29DrUKq388m4UUyOdWakUH/msGypOg==}
+    engines: {node: '>=6.0.0'}
 
   fast-glob@3.3.1:
     resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
@@ -1457,6 +1548,10 @@ packages:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
 
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
+
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
 
@@ -1651,6 +1746,9 @@ packages:
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -2126,6 +2224,9 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
   react-markdown@9.0.3:
     resolution: {integrity: sha512-Yk7Z94dbgYTOrdk41Z74GoKA7rThnsbbqBTRYuxoe08qvfQ9tJVhmAKw6BJS/ZORG7kTy/s1QvYzSuaoBA1qfw==}
     peerDependencies:
@@ -2152,6 +2253,12 @@ packages:
       '@types/react':
         optional: true
 
+  react-smooth@4.0.4:
+    resolution: {integrity: sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   react-style-singleton@2.2.3:
     resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
     engines: {node: '>=10'}
@@ -2161,6 +2268,12 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  react-transition-group@4.4.5:
+    resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
+    peerDependencies:
+      react: '>=16.6.0'
+      react-dom: '>=16.6.0'
 
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
@@ -2172,6 +2285,16 @@ packages:
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
+
+  recharts-scale@0.4.5:
+    resolution: {integrity: sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==}
+
+  recharts@2.15.4:
+    resolution: {integrity: sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -2416,6 +2539,9 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -2531,6 +2657,9 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  victory-vendor@36.9.2:
+    resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
+
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
@@ -2600,6 +2729,8 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@babel/runtime@7.28.4': {}
 
   '@emnapi/runtime@1.3.1':
     dependencies:
@@ -3102,6 +3233,30 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.7':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
@@ -3452,6 +3607,44 @@ snapshots:
 
   csstype@3.1.3: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.0: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.0
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
   damerau-levenshtein@1.0.8: {}
 
   data-view-buffer@1.0.2:
@@ -3481,6 +3674,8 @@ snapshots:
   debug@4.4.0:
     dependencies:
       ms: 2.1.3
+
+  decimal.js-light@2.5.1: {}
 
   decode-named-character-reference@1.0.2:
     dependencies:
@@ -3518,6 +3713,11 @@ snapshots:
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  dom-helpers@5.2.1:
+    dependencies:
+      '@babel/runtime': 7.28.4
+      csstype: 3.1.3
 
   dunder-proto@1.0.1:
     dependencies:
@@ -3839,9 +4039,13 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  eventemitter3@4.0.7: {}
+
   extend@3.0.2: {}
 
   fast-deep-equal@3.1.3: {}
+
+  fast-equals@5.3.4: {}
 
   fast-glob@3.3.1:
     dependencies:
@@ -4103,6 +4307,8 @@ snapshots:
       hasown: 2.0.2
       side-channel: 1.1.0
 
+  internmap@2.0.3: {}
+
   is-alphabetical@2.0.1: {}
 
   is-alphanumerical@2.0.1:
@@ -4302,6 +4508,8 @@ snapshots:
       p-locate: 5.0.0
 
   lodash.merge@4.6.2: {}
+
+  lodash@4.17.21: {}
 
   longest-streak@3.1.0: {}
 
@@ -4919,6 +5127,8 @@ snapshots:
 
   react-is@16.13.1: {}
 
+  react-is@18.3.1: {}
+
   react-markdown@9.0.3(@types/react@19.0.8)(react@18.3.1):
     dependencies:
       '@types/hast': 3.0.4
@@ -4955,6 +5165,14 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.0.8
 
+  react-smooth@4.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      fast-equals: 5.3.4
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-transition-group: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+
   react-style-singleton@2.2.3(@types/react@19.0.8)(react@18.3.1):
     dependencies:
       get-nonce: 1.0.1
@@ -4962,6 +5180,15 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.0.8
+
+  react-transition-group@4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.28.4
+      dom-helpers: 5.2.1
+      loose-envify: 1.4.0
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   react@18.3.1:
     dependencies:
@@ -4974,6 +5201,23 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
+
+  recharts-scale@0.4.5:
+    dependencies:
+      decimal.js-light: 2.5.1
+
+  recharts@2.15.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      clsx: 2.1.1
+      eventemitter3: 4.0.7
+      lodash: 4.17.21
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-is: 18.3.1
+      react-smooth: 4.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      recharts-scale: 0.4.5
+      tiny-invariant: 1.3.3
+      victory-vendor: 36.9.2
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -5339,6 +5583,8 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  tiny-invariant@1.3.3: {}
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -5482,6 +5728,23 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
+
+  victory-vendor@36.9.2:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.7
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   web-namespaces@2.0.1: {}
 

--- a/src/components/chat/ChatArea/Messages/Charts/AreaChartCard.tsx
+++ b/src/components/chat/ChatArea/Messages/Charts/AreaChartCard.tsx
@@ -1,0 +1,119 @@
+'use client'
+
+import { memo } from 'react'
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer
+} from 'recharts'
+import type { ChartConfig, ChartSeries } from '@/types/os'
+
+// Theme colors matching Tailwind config
+const THEME = {
+  grid: '#27272A',
+  axis: '#A1A1AA',
+  tooltipBg: '#111113',
+  tooltipBorder: '#27272A',
+  tooltipLabel: '#FAFAFA'
+}
+
+const COLORS = [
+  '#22c55e',
+  '#3b82f6',
+  '#eab308',
+  '#f97316',
+  '#ec4899',
+  '#a855f7'
+]
+
+// Generate fill color with opacity
+const getFillColor = (color: string) => {
+  // Convert hex to rgba with 0.3 opacity
+  const hex = color.replace('#', '')
+  const r = parseInt(hex.substring(0, 2), 16)
+  const g = parseInt(hex.substring(2, 4), 16)
+  const b = parseInt(hex.substring(4, 6), 16)
+  return `rgba(${r}, ${g}, ${b}, 0.3)`
+}
+
+interface AreaChartCardProps {
+  data: Array<Record<string, string | number | null>>
+  config: ChartConfig
+  height: number
+}
+
+const AreaChartCard = memo(({ data, config, height }: AreaChartCardProps) => {
+  const { xKey = 'x', series = [] } = config
+
+  // If no series defined, try to infer from data keys
+  const effectiveSeries: ChartSeries[] =
+    series.length > 0
+      ? series
+      : data.length > 0
+        ? Object.keys(data[0])
+            .filter((key) => key !== xKey)
+            .map((key) => ({ key, label: key }))
+        : []
+
+  const prefersReducedMotion = window.matchMedia(
+    '(prefers-reduced-motion: reduce)'
+  ).matches
+
+  return (
+    <ResponsiveContainer width="100%" height={height}>
+      <AreaChart
+        data={data}
+        margin={{ top: 5, right: 20, left: 10, bottom: 5 }}
+      >
+        <CartesianGrid strokeDasharray="3 3" stroke={THEME.grid} />
+        <XAxis
+          dataKey={xKey}
+          stroke={THEME.axis}
+          fontSize={12}
+          tickLine={false}
+          axisLine={false}
+        />
+        <YAxis
+          stroke={THEME.axis}
+          fontSize={12}
+          tickLine={false}
+          axisLine={false}
+        />
+        <Tooltip
+          contentStyle={{
+            backgroundColor: THEME.tooltipBg,
+            border: `1px solid ${THEME.tooltipBorder}`,
+            borderRadius: '8px',
+            fontSize: '12px'
+          }}
+          labelStyle={{ color: THEME.tooltipLabel }}
+        />
+        <Legend wrapperStyle={{ fontSize: '12px' }} />
+        {effectiveSeries.map((s, idx) => {
+          const strokeColor = s.color || COLORS[idx % COLORS.length]
+          return (
+            <Area
+              key={s.key}
+              type="monotone"
+              dataKey={s.key}
+              name={s.label || s.key}
+              stroke={strokeColor}
+              fill={getFillColor(strokeColor)}
+              strokeWidth={2}
+              isAnimationActive={!prefersReducedMotion}
+            />
+          )
+        })}
+      </AreaChart>
+    </ResponsiveContainer>
+  )
+})
+
+AreaChartCard.displayName = 'AreaChartCard'
+
+export default AreaChartCard

--- a/src/components/chat/ChatArea/Messages/Charts/BarChartCard.tsx
+++ b/src/components/chat/ChatArea/Messages/Charts/BarChartCard.tsx
@@ -1,0 +1,101 @@
+'use client'
+
+import { memo } from 'react'
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer
+} from 'recharts'
+import type { ChartConfig, ChartSeries } from '@/types/os'
+
+// Theme colors matching Tailwind config
+const THEME = {
+  grid: '#27272A',
+  axis: '#A1A1AA',
+  tooltipBg: '#111113',
+  tooltipBorder: '#27272A',
+  tooltipLabel: '#FAFAFA',
+  cursorFill: 'rgba(39, 39, 42, 0.5)'
+}
+
+const COLORS = [
+  '#22c55e',
+  '#3b82f6',
+  '#eab308',
+  '#f97316',
+  '#ec4899',
+  '#a855f7'
+]
+
+interface BarChartCardProps {
+  data: Array<Record<string, string | number | null>>
+  config: ChartConfig
+  height: number
+}
+
+const BarChartCard = memo(({ data, config, height }: BarChartCardProps) => {
+  const { xKey = 'x', series = [] } = config
+
+  // If no series defined, try to infer from data keys
+  const effectiveSeries: ChartSeries[] =
+    series.length > 0
+      ? series
+      : data.length > 0
+        ? Object.keys(data[0])
+            .filter((key) => key !== xKey)
+            .map((key) => ({ key, label: key }))
+        : []
+
+  return (
+    <ResponsiveContainer width="100%" height={height}>
+      <BarChart data={data} margin={{ top: 5, right: 20, left: 10, bottom: 5 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke={THEME.grid} />
+        <XAxis
+          dataKey={xKey}
+          stroke={THEME.axis}
+          fontSize={12}
+          tickLine={false}
+          axisLine={false}
+        />
+        <YAxis
+          stroke={THEME.axis}
+          fontSize={12}
+          tickLine={false}
+          axisLine={false}
+        />
+        <Tooltip
+          contentStyle={{
+            backgroundColor: THEME.tooltipBg,
+            border: `1px solid ${THEME.tooltipBorder}`,
+            borderRadius: '8px',
+            fontSize: '12px'
+          }}
+          labelStyle={{ color: THEME.tooltipLabel }}
+          cursor={{ fill: THEME.cursorFill }}
+        />
+        <Legend wrapperStyle={{ fontSize: '12px' }} />
+        {effectiveSeries.map((s, idx) => (
+          <Bar
+            key={s.key}
+            dataKey={s.key}
+            name={s.label || s.key}
+            fill={s.color || COLORS[idx % COLORS.length]}
+            radius={[4, 4, 0, 0]}
+            isAnimationActive={
+              !window.matchMedia('(prefers-reduced-motion: reduce)').matches
+            }
+          />
+        ))}
+      </BarChart>
+    </ResponsiveContainer>
+  )
+})
+
+BarChartCard.displayName = 'BarChartCard'
+
+export default BarChartCard

--- a/src/components/chat/ChatArea/Messages/Charts/ChartRenderer.tsx
+++ b/src/components/chat/ChatArea/Messages/Charts/ChartRenderer.tsx
@@ -1,0 +1,111 @@
+'use client'
+
+import { memo } from 'react'
+import { cn } from '@/lib/utils'
+import type { ChartData } from '@/types/os'
+import LineChartCard from './LineChartCard'
+import BarChartCard from './BarChartCard'
+import PieChartCard from './PieChartCard'
+import AreaChartCard from './AreaChartCard'
+
+interface ChartRendererProps {
+  chart: ChartData
+  className?: string
+}
+
+// Runtime shape guard to prevent Recharts crashes from malformed payloads
+const isValidChartData = (chart: unknown): chart is ChartData => {
+  if (!chart || typeof chart !== 'object') return false
+  const c = chart as Record<string, unknown>
+  if (!c.config || typeof c.config !== 'object') return false
+  if (!c.data || !Array.isArray(c.data)) return false
+  const config = c.config as Record<string, unknown>
+  if (typeof config.type !== 'string') return false
+  return true
+}
+
+const ChartRenderer = memo(({ chart, className }: ChartRendererProps) => {
+  // Validate chart shape before accessing properties
+  if (!isValidChartData(chart)) {
+    return (
+      <div
+        className={cn(
+          'w-full max-w-xl rounded-lg border border-border bg-background p-4',
+          className
+        )}
+        role="figure"
+        aria-label="Chart"
+      >
+        <div className="flex h-32 items-center justify-center text-sm text-muted">
+          Invalid chart data
+        </div>
+      </div>
+    )
+  }
+
+  const { config, data } = chart
+  const { type, title, height = 300 } = config
+
+  // Guard against empty data
+  if (data.length === 0) {
+    return (
+      <div
+        className={cn(
+          'w-full max-w-xl rounded-lg border border-border bg-background p-4',
+          className
+        )}
+        role="figure"
+        aria-label={title || 'Chart'}
+      >
+        {title && (
+          <div className="mb-3 text-sm font-medium text-primary">{title}</div>
+        )}
+        <div className="flex h-32 items-center justify-center text-sm text-muted">
+          No data available
+        </div>
+      </div>
+    )
+  }
+
+  const renderChart = () => {
+    switch (type) {
+      case 'line':
+        return <LineChartCard data={data} config={config} height={height} />
+      case 'bar':
+        return <BarChartCard data={data} config={config} height={height} />
+      case 'pie':
+        return <PieChartCard data={data} config={config} height={height} />
+      case 'area':
+        return <AreaChartCard data={data} config={config} height={height} />
+      case 'funnel':
+        // Funnel uses bar chart as fallback for now
+        return <BarChartCard data={data} config={config} height={height} />
+      default:
+        return (
+          <div className="text-sm text-muted">
+            Unsupported chart type: {type}
+          </div>
+        )
+    }
+  }
+
+  return (
+    <div
+      className={cn(
+        'w-full max-w-xl rounded-lg border border-border bg-background p-4',
+        className
+      )}
+      role="figure"
+      aria-label={title || `${type} chart`}
+    >
+      {title && (
+        <div className="mb-3 text-sm font-medium text-primary">{title}</div>
+      )}
+      {renderChart()}
+    </div>
+  )
+})
+
+ChartRenderer.displayName = 'ChartRenderer'
+
+export default ChartRenderer

--- a/src/components/chat/ChatArea/Messages/Charts/LineChartCard.tsx
+++ b/src/components/chat/ChatArea/Messages/Charts/LineChartCard.tsx
@@ -1,0 +1,105 @@
+'use client'
+
+import { memo } from 'react'
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer
+} from 'recharts'
+import type { ChartConfig, ChartSeries } from '@/types/os'
+
+// Theme colors matching Tailwind config
+const THEME = {
+  grid: '#27272A',
+  axis: '#A1A1AA',
+  tooltipBg: '#111113',
+  tooltipBorder: '#27272A',
+  tooltipLabel: '#FAFAFA'
+}
+
+const COLORS = [
+  '#22c55e',
+  '#3b82f6',
+  '#eab308',
+  '#f97316',
+  '#ec4899',
+  '#a855f7'
+]
+
+interface LineChartCardProps {
+  data: Array<Record<string, string | number | null>>
+  config: ChartConfig
+  height: number
+}
+
+const LineChartCard = memo(({ data, config, height }: LineChartCardProps) => {
+  const { xKey = 'x', series = [] } = config
+
+  // If no series defined, try to infer from data keys
+  const effectiveSeries: ChartSeries[] =
+    series.length > 0
+      ? series
+      : data.length > 0
+        ? Object.keys(data[0])
+            .filter((key) => key !== xKey)
+            .map((key) => ({ key, label: key }))
+        : []
+
+  return (
+    <ResponsiveContainer width="100%" height={height}>
+      <LineChart
+        data={data}
+        margin={{ top: 5, right: 20, left: 10, bottom: 5 }}
+      >
+        <CartesianGrid strokeDasharray="3 3" stroke={THEME.grid} />
+        <XAxis
+          dataKey={xKey}
+          stroke={THEME.axis}
+          fontSize={12}
+          tickLine={false}
+          axisLine={false}
+        />
+        <YAxis
+          stroke={THEME.axis}
+          fontSize={12}
+          tickLine={false}
+          axisLine={false}
+        />
+        <Tooltip
+          contentStyle={{
+            backgroundColor: THEME.tooltipBg,
+            border: `1px solid ${THEME.tooltipBorder}`,
+            borderRadius: '8px',
+            fontSize: '12px'
+          }}
+          labelStyle={{ color: THEME.tooltipLabel }}
+        />
+        <Legend wrapperStyle={{ fontSize: '12px' }} />
+        {effectiveSeries.map((s, idx) => (
+          <Line
+            key={s.key}
+            type="monotone"
+            dataKey={s.key}
+            name={s.label || s.key}
+            stroke={s.color || COLORS[idx % COLORS.length]}
+            strokeWidth={2}
+            dot={false}
+            activeDot={{ r: 4 }}
+            isAnimationActive={
+              !window.matchMedia('(prefers-reduced-motion: reduce)').matches
+            }
+          />
+        ))}
+      </LineChart>
+    </ResponsiveContainer>
+  )
+})
+
+LineChartCard.displayName = 'LineChartCard'
+
+export default LineChartCard

--- a/src/components/chat/ChatArea/Messages/Charts/PieChartCard.tsx
+++ b/src/components/chat/ChatArea/Messages/Charts/PieChartCard.tsx
@@ -1,0 +1,101 @@
+'use client'
+
+import { memo } from 'react'
+import {
+  PieChart,
+  Pie,
+  Cell,
+  Tooltip,
+  Legend,
+  ResponsiveContainer
+} from 'recharts'
+import type { ChartConfig } from '@/types/os'
+
+// Theme colors matching Tailwind config
+const THEME = {
+  tooltipBg: '#111113',
+  tooltipBorder: '#27272A',
+  tooltipLabel: '#FAFAFA',
+  legendText: '#A1A1AA'
+}
+
+const COLORS = [
+  '#22c55e',
+  '#3b82f6',
+  '#eab308',
+  '#f97316',
+  '#ec4899',
+  '#a855f7',
+  '#06b6d4',
+  '#84cc16'
+]
+
+interface PieChartCardProps {
+  data: Array<Record<string, string | number | null>>
+  config: ChartConfig
+  height: number
+}
+
+const PieChartCard = memo(({ data, config, height }: PieChartCardProps) => {
+  const { xKey = 'name', series = [] } = config
+
+  // For pie charts, use the first series key as the value key
+  const valueKey =
+    series[0]?.key ||
+    (data.length > 0
+      ? Object.keys(data[0]).find(
+          (key) => key !== xKey && typeof data[0]?.[key] === 'number'
+        )
+      : undefined) ||
+    'value'
+
+  const prefersReducedMotion = window.matchMedia(
+    '(prefers-reduced-motion: reduce)'
+  ).matches
+
+  return (
+    <ResponsiveContainer width="100%" height={height}>
+      <PieChart>
+        <Pie
+          data={data}
+          dataKey={valueKey}
+          nameKey={xKey}
+          cx="50%"
+          cy="50%"
+          outerRadius={Math.min(height * 0.35, 120)}
+          label={({ name, percent }) => {
+            const displayName = name != null ? String(name) : ''
+            const displayPercent =
+              typeof percent === 'number' ? (percent * 100).toFixed(0) : '0'
+            return `${displayName} ${displayPercent}%`
+          }}
+          labelLine={false}
+          isAnimationActive={!prefersReducedMotion}
+        >
+          {data.map((_, index) => (
+            <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+          ))}
+        </Pie>
+        <Tooltip
+          contentStyle={{
+            backgroundColor: THEME.tooltipBg,
+            border: `1px solid ${THEME.tooltipBorder}`,
+            borderRadius: '8px',
+            fontSize: '12px'
+          }}
+          labelStyle={{ color: THEME.tooltipLabel }}
+        />
+        <Legend
+          wrapperStyle={{ fontSize: '12px' }}
+          formatter={(value) => (
+            <span style={{ color: THEME.legendText }}>{value}</span>
+          )}
+        />
+      </PieChart>
+    </ResponsiveContainer>
+  )
+})
+
+PieChartCard.displayName = 'PieChartCard'
+
+export default PieChartCard

--- a/src/components/chat/ChatArea/Messages/Charts/index.ts
+++ b/src/components/chat/ChatArea/Messages/Charts/index.ts
@@ -1,0 +1,3 @@
+import Charts from './ChartRenderer'
+
+export default Charts

--- a/src/components/chat/ChatArea/Messages/MessageItem.tsx
+++ b/src/components/chat/ChatArea/Messages/MessageItem.tsx
@@ -5,6 +5,7 @@ import type { ChatMessage } from '@/types/os'
 import Videos from './Multimedia/Videos'
 import Images from './Multimedia/Images'
 import Audios from './Multimedia/Audios'
+import Charts from './Charts'
 import { memo } from 'react'
 import AgentThinkingLoader from './AgentThinkingLoader'
 
@@ -26,10 +27,13 @@ const AgentMessage = ({ message }: MessageProps) => {
         )}
       </p>
     )
-  } else if (message.content) {
+  } else if (message.content || message.chart) {
     messageContent = (
       <div className="flex w-full flex-col gap-4">
-        <MarkdownRenderer>{message.content}</MarkdownRenderer>
+        {message.content && (
+          <MarkdownRenderer>{message.content}</MarkdownRenderer>
+        )}
+        {message.chart && <Charts chart={message.chart} />}
         {message.videos && message.videos.length > 0 && (
           <Videos videos={message.videos} />
         )}

--- a/src/hooks/useSessionLoader.tsx
+++ b/src/hooks/useSessionLoader.tsx
@@ -126,6 +126,7 @@ const useSessionLoader = () => {
                   videos: run.videos,
                   audio: run.audio,
                   response_audio: run.response_audio,
+                  chart: run.chart,
                   created_at: run.created_at
                 })
               }

--- a/src/types/os.ts
+++ b/src/types/os.ts
@@ -147,6 +147,7 @@ export interface RunResponseContent {
   videos?: VideoData[]
   audio?: AudioData[]
   response_audio?: ResponseAudio
+  chart?: ChartData
 }
 
 export interface RunResponse {
@@ -169,15 +170,11 @@ export interface RunResponse {
   videos?: VideoData[]
   audio?: AudioData[]
   response_audio?: ResponseAudio
+  chart?: ChartData
 }
 
 export interface AgentExtraData {
   reasoning_steps?: ReasoningSteps[]
-  reasoning_messages?: ReasoningMessage[]
-  references?: ReferenceData[]
-}
-
-export interface AgentExtraData {
   reasoning_messages?: ReasoningMessage[]
   references?: ReferenceData[]
 }
@@ -209,6 +206,7 @@ export interface ChatMessage {
   videos?: VideoData[]
   audio?: AudioData[]
   response_audio?: ResponseAudio
+  chart?: ChartData
 }
 
 export interface AgentDetails {
@@ -247,6 +245,28 @@ export interface AudioData {
   content?: string
   channels?: number
   sample_rate?: number
+}
+
+// Chart visualization types
+export type ChartType = 'line' | 'bar' | 'pie' | 'area' | 'funnel'
+
+export interface ChartSeries {
+  key: string
+  label?: string
+  color?: string
+}
+
+export interface ChartConfig {
+  type: ChartType
+  title?: string
+  xKey?: string
+  series?: ChartSeries[]
+  height?: number
+}
+
+export interface ChartData {
+  config: ChartConfig
+  data: Array<Record<string, string | number | null>>
 }
 
 export interface ReferenceData {
@@ -303,6 +323,7 @@ export interface ChatEntry {
     response_audio?: {
       transcript?: string
     }
+    chart?: ChartData
     created_at: number
   }
 }


### PR DESCRIPTION
Implements chart rendering support for agent messages, allowing agents to return structured chart data that renders as interactive visualizations.

## Features
- Line, bar, pie, area, and funnel chart types via Recharts
- Auto-detection via `content_type: "chart"` in streaming responses
- Dark theme styling matching existing Tailwind config
- Session history persistence for charts
- Runtime shape validation to prevent crashes from malformed payloads
- Reduced motion support for accessibility
- Empty data state handling

Chart components follow the existing multimedia pattern (Images, Videos, Audios) with `memo()` optimization and `ResponsiveContainer` for responsive sizing.

## Backend Contract

Agents can emit charts by sending:
```json
{
  "event": "RunContent",
  "content_type": "chart",
  "content": {
    "config": {
      "type": "line",
      "title": "Monthly Sales",
      "xKey": "month",
      "series": [{"key": "revenue", "label": "Revenue"}]
    },
    "data": [
      {"month": "Jan", "revenue": 100},
      {"month": "Feb", "revenue": 150}
    ]
  }
}
```

## Files Changed
- `src/components/chat/ChatArea/Messages/Charts/` - New chart components
- `src/types/os.ts` - ChartData, ChartConfig, ChartSeries types
- `src/hooks/useAIStreamHandler.tsx` - Stream handling for chart content
- `src/hooks/useSessionLoader.tsx` - Session history persistence
- `src/components/chat/ChatArea/Messages/MessageItem.tsx` - Render charts in messages
- `package.json` - Added recharts dependency

Closes #119