### PR TITLE
Add per-message RTL rendering and RTL font support

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -11,6 +11,34 @@
   body {
     @apply bg-background/80 text-secondary;
   }
+
+  [dir='rtl'] {
+    font-family: var(--font-vazirmatn), var(--font-geist-sans), sans-serif;
+  }
+}
+
+@layer utilities {
+  .font-inherit {
+    font-family: inherit !important;
+  }
+
+  .font-vazirmatn {
+    font-family: var(--font-vazirmatn), var(--font-geist-sans), sans-serif !important;
+  }
+
+  .rtl-logical-indent {
+    padding-inline-start: 2.5rem;
+  }
+
+  .bidi-plaintext {
+    unicode-bidi: plaintext;
+  }
+
+  .ltr-content {
+    direction: ltr;
+    text-align: left;
+    unicode-bidi: isolate;
+  }
 }
 
 ::-webkit-scrollbar {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next'
-import { DM_Mono, Geist } from 'next/font/google'
+import { DM_Mono, Geist, Vazirmatn } from 'next/font/google'
 import { NuqsAdapter } from 'nuqs/adapters/next/app'
 import { Toaster } from '@/components/ui/sonner'
 import './globals.css'
@@ -15,6 +15,12 @@ const dmMono = DM_Mono({
   weight: '400'
 })
 
+const vazirmatn = Vazirmatn({
+  variable: '--font-vazirmatn',
+  subsets: ['arabic', 'latin'],
+  weight: ['400', '500', '700']
+})
+
 export const metadata: Metadata = {
   title: 'Agent UI',
   description:
@@ -28,7 +34,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${geistSans.variable} ${dmMono.variable} antialiased`}>
+      <body
+        className={`${geistSans.variable} ${dmMono.variable} ${vazirmatn.variable} antialiased`}
+      >
         <NuqsAdapter>{children}</NuqsAdapter>
         <Toaster />
       </body>

--- a/src/components/chat/ChatArea/ChatInput/ChatInput.tsx
+++ b/src/components/chat/ChatArea/ChatInput/ChatInput.tsx
@@ -38,6 +38,7 @@ const ChatInput = () => {
       <TextArea
         placeholder={'Ask anything'}
         value={inputMessage}
+        dir="auto"
         onChange={(e) => setInputMessage(e.target.value)}
         onKeyDown={(e) => {
           if (

--- a/src/components/ui/typography/MarkdownRenderer/MarkdownRenderer.tsx
+++ b/src/components/ui/typography/MarkdownRenderer/MarkdownRenderer.tsx
@@ -15,17 +15,19 @@ const MarkdownRenderer: FC<MarkdownRendererProps> = ({
   classname,
   inline = false
 }) => (
-  <ReactMarkdown
-    className={cn(
-      'prose prose-h1:text-xl dark:prose-invert flex w-full flex-col gap-y-5 rounded-lg',
-      classname
-    )}
-    components={{ ...(inline ? inlineComponents : components) }}
-    remarkPlugins={[remarkGfm]}
-    rehypePlugins={[rehypeRaw, rehypeSanitize]}
-  >
-    {children}
-  </ReactMarkdown>
+  <div dir="auto">
+    <ReactMarkdown
+      className={cn(
+        'directional-markdown prose prose-h1:text-xl dark:prose-invert flex w-full flex-col gap-y-5 rounded-lg',
+        classname
+      )}
+      components={{ ...(inline ? inlineComponents : components) }}
+      remarkPlugins={[remarkGfm]}
+      rehypePlugins={[rehypeRaw, rehypeSanitize]}
+    >
+      {children}
+    </ReactMarkdown>
+  </div>
 )
 
 export default MarkdownRenderer

--- a/src/components/ui/typography/MarkdownRenderer/inlineStyles.tsx
+++ b/src/components/ui/typography/MarkdownRenderer/inlineStyles.tsx
@@ -10,6 +10,7 @@ import { cn } from '@/lib/utils'
 import type {
   UnorderedListProps,
   OrderedListProps,
+  ListItemProps,
   EmphasizedTextProps,
   ItalicTextProps,
   StrongTextProps,
@@ -41,8 +42,9 @@ const UnorderedList = ({ className, ...props }: UnorderedListProps) => (
     className={cn(
       className,
       PARAGRAPH_SIZES.lead,
-      'flex list-disc flex-col pl-10'
+      'font-inherit rtl-logical-indent flex list-disc flex-col bidi-plaintext text-start'
     )}
+    dir="auto"
     {...filterProps(props)}
   />
 )
@@ -52,51 +54,76 @@ const OrderedList = ({ className, ...props }: OrderedListProps) => (
     className={cn(
       className,
       PARAGRAPH_SIZES.lead,
-      'flex list-decimal flex-col pl-10'
+      'font-inherit rtl-logical-indent flex list-decimal flex-col bidi-plaintext text-start'
     )}
+    dir="auto"
+    {...filterProps(props)}
+  />
+)
+
+const ListItem = ({ className, ...props }: ListItemProps) => (
+  <li
+    className={cn(className, 'bidi-plaintext text-start')}
+    dir="auto"
     {...filterProps(props)}
   />
 )
 
 const Paragraph = ({ className, ...props }: ParagraphProps) => (
-  <p className={cn(className, PARAGRAPH_SIZES.lead)} {...filterProps(props)} />
+  <p
+    className={cn(
+      className,
+      PARAGRAPH_SIZES.lead,
+      'font-inherit bidi-plaintext text-start'
+    )}
+    dir="auto"
+    {...filterProps(props)}
+  />
 )
 
 const EmphasizedText = ({ className, ...props }: EmphasizedTextProps) => (
   <em
-    className={cn(className, 'PARAGRAPH_SIZES.lead')}
+    className={cn(className, PARAGRAPH_SIZES.lead, 'font-inherit')}
     {...filterProps(props)}
   />
 )
 
 const ItalicText = ({ className, ...props }: ItalicTextProps) => (
-  <i className={cn(className, PARAGRAPH_SIZES.lead)} {...filterProps(props)} />
+  <i
+    className={cn(className, PARAGRAPH_SIZES.lead, 'font-inherit')}
+    {...filterProps(props)}
+  />
 )
 
 const StrongText = ({ className, ...props }: StrongTextProps) => (
   <strong
-    className={cn(className, 'PARAGRAPH_SIZES.lead')}
+    className={cn(className, PARAGRAPH_SIZES.lead, 'font-inherit')}
     {...filterProps(props)}
   />
 )
 
 const BoldText = ({ className, ...props }: BoldTextProps) => (
   <b
-    className={cn(className, 'PARAGRAPH_SIZES.lead')}
+    className={cn(className, PARAGRAPH_SIZES.lead, 'font-inherit')}
     {...filterProps(props)}
   />
 )
 
 const UnderlinedText = ({ className, ...props }: UnderlinedTextProps) => (
   <u
-    className={cn(className, 'underline', PARAGRAPH_SIZES.lead)}
+    className={cn(className, 'underline', PARAGRAPH_SIZES.lead, 'font-inherit')}
     {...filterProps(props)}
   />
 )
 
 const DeletedText = ({ className, ...props }: DeletedTextProps) => (
   <del
-    className={cn(className, 'text-muted line-through', PARAGRAPH_SIZES.lead)}
+    className={cn(
+      className,
+      'text-muted line-through',
+      PARAGRAPH_SIZES.lead,
+      'font-inherit'
+    )}
     {...filterProps(props)}
   />
 )
@@ -110,7 +137,12 @@ const HorizontalRule = ({ className, ...props }: HorizontalRuleProps) => (
 
 const Blockquote = ({ className, ...props }: BlockquoteProps) => (
   <blockquote
-    className={cn(className, PARAGRAPH_SIZES.lead)}
+    className={cn(
+      className,
+      PARAGRAPH_SIZES.lead,
+      'font-inherit bidi-plaintext text-start'
+    )}
+    dir="auto"
     {...filterProps(props)}
   />
 )
@@ -125,27 +157,75 @@ const AnchorLink = ({ className, ...props }: AnchorLinkProps) => (
 )
 
 const Heading1 = ({ className, ...props }: HeadingProps) => (
-  <h1 className={cn(className, PARAGRAPH_SIZES.lead)} {...filterProps(props)} />
+  <h1
+    className={cn(
+      className,
+      PARAGRAPH_SIZES.lead,
+      'font-inherit bidi-plaintext text-start'
+    )}
+    dir="auto"
+    {...filterProps(props)}
+  />
 )
 
 const Heading2 = ({ className, ...props }: HeadingProps) => (
-  <h2 className={cn(className, PARAGRAPH_SIZES.lead)} {...filterProps(props)} />
+  <h2
+    className={cn(
+      className,
+      PARAGRAPH_SIZES.lead,
+      'font-inherit bidi-plaintext text-start'
+    )}
+    dir="auto"
+    {...filterProps(props)}
+  />
 )
 
 const Heading3 = ({ className, ...props }: HeadingProps) => (
-  <h3 className={cn(className, PARAGRAPH_SIZES.lead)} {...filterProps(props)} />
+  <h3
+    className={cn(
+      className,
+      PARAGRAPH_SIZES.lead,
+      'font-inherit bidi-plaintext text-start'
+    )}
+    dir="auto"
+    {...filterProps(props)}
+  />
 )
 
 const Heading4 = ({ className, ...props }: HeadingProps) => (
-  <h4 className={cn(className, PARAGRAPH_SIZES.lead)} {...filterProps(props)} />
+  <h4
+    className={cn(
+      className,
+      PARAGRAPH_SIZES.lead,
+      'font-inherit bidi-plaintext text-start'
+    )}
+    dir="auto"
+    {...filterProps(props)}
+  />
 )
 
 const Heading5 = ({ className, ...props }: HeadingProps) => (
-  <h5 className={cn(className, PARAGRAPH_SIZES.lead)} {...filterProps(props)} />
+  <h5
+    className={cn(
+      className,
+      PARAGRAPH_SIZES.lead,
+      'font-inherit bidi-plaintext text-start'
+    )}
+    dir="auto"
+    {...filterProps(props)}
+  />
 )
 
 const Heading6 = ({ className, ...props }: HeadingProps) => (
-  <h6 className={cn(className, PARAGRAPH_SIZES.lead)} {...filterProps(props)} />
+  <h6
+    className={cn(
+      className,
+      PARAGRAPH_SIZES.lead,
+      'font-inherit bidi-plaintext text-start'
+    )}
+    dir="auto"
+    {...filterProps(props)}
+  />
 )
 
 const Img = ({ src, alt }: ImgProps) => {
@@ -190,6 +270,7 @@ export const inlineComponents = {
   h6: Heading6,
   ul: UnorderedList,
   ol: OrderedList,
+  li: ListItem,
   em: EmphasizedText,
   i: ItalicText,
   strong: StrongText,

--- a/src/components/ui/typography/MarkdownRenderer/styles.tsx
+++ b/src/components/ui/typography/MarkdownRenderer/styles.tsx
@@ -9,6 +9,7 @@ import { cn } from '@/lib/utils'
 import type {
   UnorderedListProps,
   OrderedListProps,
+  ListItemProps,
   EmphasizedTextProps,
   ItalicTextProps,
   StrongTextProps,
@@ -27,7 +28,8 @@ import type {
   TableBodyProps,
   TableRowProps,
   TableCellProps,
-  PreparedTextProps
+  CodeTextProps,
+  PreformattedTextProps
 } from './types'
 
 import { HEADING_SIZES } from '../Heading/constants'
@@ -48,8 +50,9 @@ const UnorderedList = ({ className, ...props }: UnorderedListProps) => (
     className={cn(
       className,
       PARAGRAPH_SIZES.body,
-      'flex list-disc flex-col pl-10'
+      'font-inherit rtl-logical-indent flex list-disc flex-col bidi-plaintext text-start'
     )}
+    dir="auto"
     {...filterProps(props)}
   />
 )
@@ -59,15 +62,29 @@ const OrderedList = ({ className, ...props }: OrderedListProps) => (
     className={cn(
       className,
       PARAGRAPH_SIZES.body,
-      'flex list-decimal flex-col pl-10'
+      'font-inherit rtl-logical-indent flex list-decimal flex-col bidi-plaintext text-start'
     )}
+    dir="auto"
+    {...filterProps(props)}
+  />
+)
+
+const ListItem = ({ className, ...props }: ListItemProps) => (
+  <li
+    className={cn(className, 'bidi-plaintext text-start')}
+    dir="auto"
     {...filterProps(props)}
   />
 )
 
 const Paragraph = ({ className, ...props }: ParagraphProps) => (
-  <div
-    className={cn(className, PARAGRAPH_SIZES.body)}
+  <p
+    className={cn(
+      className,
+      PARAGRAPH_SIZES.body,
+      'font-inherit bidi-plaintext text-start'
+    )}
+    dir="auto"
     {...filterProps(props)}
   />
 )
@@ -81,7 +98,7 @@ const EmphasizedText = ({ className, ...props }: EmphasizedTextProps) => (
 
 const ItalicText = ({ className, ...props }: ItalicTextProps) => (
   <i
-    className={cn(className, 'italic', PARAGRAPH_SIZES.body)}
+    className={cn(className, 'italic', PARAGRAPH_SIZES.body, 'font-inherit')}
     {...filterProps(props)}
   />
 )
@@ -102,14 +119,24 @@ const BoldText = ({ className, ...props }: BoldTextProps) => (
 
 const UnderlinedText = ({ className, ...props }: UnderlinedTextProps) => (
   <u
-    className={cn(className, 'underline', PARAGRAPH_SIZES.body)}
+    className={cn(
+      className,
+      'underline',
+      PARAGRAPH_SIZES.body,
+      'font-inherit'
+    )}
     {...filterProps(props)}
   />
 )
 
 const DeletedText = ({ className, ...props }: DeletedTextProps) => (
   <del
-    className={cn(className, 'text-muted line-through', PARAGRAPH_SIZES.body)}
+    className={cn(
+      className,
+      'text-muted line-through',
+      PARAGRAPH_SIZES.body,
+      'font-inherit'
+    )}
     {...filterProps(props)}
   />
 )
@@ -121,17 +148,43 @@ const HorizontalRule = ({ className, ...props }: HorizontalRuleProps) => (
   />
 )
 
-const InlineCode: FC<PreparedTextProps> = ({ children }) => {
+const InlineCode: FC<CodeTextProps> = ({ children, className, ...props }) => {
   return (
-    <code className="relative whitespace-pre-wrap rounded-sm bg-background-secondary/50 p-1">
+    <code
+      className={cn(
+        className,
+        'ltr-content relative whitespace-pre-wrap rounded-sm bg-background-secondary/50 p-1 text-left'
+      )}
+      dir="ltr"
+      {...filterProps(props)}
+    >
       {children}
     </code>
   )
 }
 
+const PreformattedText = ({
+  className,
+  ...props
+}: PreformattedTextProps) => (
+  <pre
+    className={cn(
+      className,
+      'ltr-content overflow-x-auto rounded-md bg-background-secondary/50 p-3 text-left font-dmmono text-xs leading-5'
+    )}
+    dir="ltr"
+    {...filterProps(props)}
+  />
+)
+
 const Blockquote = ({ className, ...props }: BlockquoteProps) => (
   <blockquote
-    className={cn(className, 'italic', PARAGRAPH_SIZES.body)}
+    className={cn(
+      className,
+      'font-inherit bidi-plaintext text-start italic',
+      PARAGRAPH_SIZES.body
+    )}
+    dir="auto"
     {...filterProps(props)}
   />
 )
@@ -146,31 +199,73 @@ const AnchorLink = ({ className, ...props }: AnchorLinkProps) => (
 )
 
 const Heading1 = ({ className, ...props }: HeadingProps) => (
-  <h1 className={cn(className, HEADING_SIZES[3])} {...filterProps(props)} />
+  <h1
+    className={cn(
+      className,
+      HEADING_SIZES[3],
+      'font-inherit bidi-plaintext text-start'
+    )}
+    dir="auto"
+    {...filterProps(props)}
+  />
 )
 
 const Heading2 = ({ className, ...props }: HeadingProps) => (
-  <h2 className={cn(className, HEADING_SIZES[3])} {...filterProps(props)} />
+  <h2
+    className={cn(
+      className,
+      HEADING_SIZES[3],
+      'font-inherit bidi-plaintext text-start'
+    )}
+    dir="auto"
+    {...filterProps(props)}
+  />
 )
 
 const Heading3 = ({ className, ...props }: HeadingProps) => (
-  <h3 className={cn(className, PARAGRAPH_SIZES.lead)} {...filterProps(props)} />
+  <h3
+    className={cn(
+      className,
+      PARAGRAPH_SIZES.lead,
+      'font-inherit bidi-plaintext text-start'
+    )}
+    dir="auto"
+    {...filterProps(props)}
+  />
 )
 
 const Heading4 = ({ className, ...props }: HeadingProps) => (
-  <h4 className={cn(className, PARAGRAPH_SIZES.lead)} {...filterProps(props)} />
+  <h4
+    className={cn(
+      className,
+      PARAGRAPH_SIZES.lead,
+      'font-inherit bidi-plaintext text-start'
+    )}
+    dir="auto"
+    {...filterProps(props)}
+  />
 )
 
 const Heading5 = ({ className, ...props }: HeadingProps) => (
   <h5
-    className={cn(className, PARAGRAPH_SIZES.title)}
+    className={cn(
+      className,
+      PARAGRAPH_SIZES.title,
+      'font-inherit bidi-plaintext text-start'
+    )}
+    dir="auto"
     {...filterProps(props)}
   />
 )
 
 const Heading6 = ({ className, ...props }: HeadingProps) => (
   <h6
-    className={cn(className, PARAGRAPH_SIZES.title)}
+    className={cn(
+      className,
+      PARAGRAPH_SIZES.title,
+      'font-inherit bidi-plaintext text-start'
+    )}
+    dir="auto"
     {...filterProps(props)}
   />
 )
@@ -211,7 +306,11 @@ const Img = ({ src, alt }: ImgProps) => {
 const Table = ({ className, ...props }: TableProps) => (
   <div className="w-full max-w-[560px] overflow-hidden rounded-md border border-border">
     <div className="w-full overflow-x-auto">
-      <table className={cn(className, 'w-full')} {...filterProps(props)} />
+      <table
+        className={cn(className, 'ltr-content w-full text-left')}
+        dir="ltr"
+        {...filterProps(props)}
+      />
     </div>
   </div>
 )
@@ -220,33 +319,41 @@ const TableHead = ({ className, ...props }: TableHeaderProps) => (
   <thead
     className={cn(
       className,
-      'rounded-md border-b border-border bg-transparent p-2 text-left text-sm font-[600]'
+      'ltr-content rounded-md border-b border-border bg-transparent p-2 text-left text-sm font-[600]'
     )}
+    dir="ltr"
     {...filterProps(props)}
   />
 )
 
 const TableHeadCell = ({ className, ...props }: TableHeaderCellProps) => (
   <th
-    className={cn(className, 'p-2 text-sm font-[600]')}
+    className={cn(className, 'ltr-content p-2 text-left text-sm font-[600]')}
+    dir="ltr"
     {...filterProps(props)}
   />
 )
 
 const TableBody = ({ className, ...props }: TableBodyProps) => (
-  <tbody className={cn(className, 'text-xs')} {...filterProps(props)} />
+  <tbody
+    className={cn(className, 'ltr-content text-xs')}
+    dir="ltr"
+    {...filterProps(props)}
+  />
 )
 
 const TableRow = ({ className, ...props }: TableRowProps) => (
   <tr
-    className={cn(className, 'border-b border-border last:border-b-0')}
+    className={cn(className, 'ltr-content border-b border-border last:border-b-0')}
+    dir="ltr"
     {...filterProps(props)}
   />
 )
 
 const TableCell = ({ className, ...props }: TableCellProps) => (
   <td
-    className={cn(className, 'whitespace-nowrap p-2 font-[400]')}
+    className={cn(className, 'ltr-content whitespace-nowrap p-2 text-left font-[400]')}
+    dir="ltr"
     {...filterProps(props)}
   />
 )
@@ -260,6 +367,7 @@ export const components = {
   h6: Heading6,
   ul: UnorderedList,
   ol: OrderedList,
+  li: ListItem,
   em: EmphasizedText,
   i: ItalicText,
   strong: StrongText,
@@ -268,6 +376,7 @@ export const components = {
   del: DeletedText,
   hr: HorizontalRule,
   blockquote: Blockquote,
+  pre: PreformattedText,
   code: InlineCode,
   a: AnchorLink,
   img: Img,

--- a/src/components/ui/typography/MarkdownRenderer/types.ts
+++ b/src/components/ui/typography/MarkdownRenderer/types.ts
@@ -28,6 +28,10 @@ type OrderedListProps = DetailedHTMLProps<
   OlHTMLAttributes<HTMLOListElement>,
   HTMLOListElement
 >
+type ListItemProps = DetailedHTMLProps<
+  HTMLAttributes<HTMLLIElement>,
+  HTMLLIElement
+>
 
 type EmphasizedTextProps = DefaultHTMLElement
 type ItalicTextProps = DefaultHTMLElement
@@ -47,7 +51,12 @@ type HorizontalRuleProps = DetailedHTMLProps<
   HTMLHRElement
 >
 
-type PreparedTextProps = DetailedHTMLProps<
+type CodeTextProps = DetailedHTMLProps<
+  HTMLAttributes<HTMLElement>,
+  HTMLElement
+>
+
+type PreformattedTextProps = DetailedHTMLProps<
   HTMLAttributes<HTMLPreElement>,
   HTMLPreElement
 >
@@ -111,6 +120,7 @@ export type {
   MarkdownRendererProps,
   UnorderedListProps,
   OrderedListProps,
+  ListItemProps,
   EmphasizedTextProps,
   ItalicTextProps,
   StrongTextProps,
@@ -118,7 +128,8 @@ export type {
   UnderlinedTextProps,
   DeletedTextProps,
   HorizontalRuleProps,
-  PreparedTextProps,
+  CodeTextProps,
+  PreformattedTextProps,
   BlockquoteProps,
   AnchorLinkProps,
   HeadingProps,

--- a/src/lib/textDirection.ts
+++ b/src/lib/textDirection.ts
@@ -1,0 +1,27 @@
+export type TextDirection = 'rtl' | 'ltr'
+
+const RTL_SCRIPT_REGEX =
+  /[\u0590-\u05FF\u0600-\u06FF\u0750-\u077F\u0870-\u08FF\uFB50-\uFDFF\uFE70-\uFEFF]/
+
+const LTR_SCRIPT_REGEX = /[A-Za-z\u00C0-\u024F]/
+
+const stripBidiControls = (text: string) =>
+  text.replace(/[\u200E\u200F\u202A-\u202E\u2066-\u2069]/g, '')
+
+export const splitLines = (text: string): string[] => text.split(/\r?\n/)
+
+export const getTextDirection = (text: string): TextDirection => {
+  const normalizedText = stripBidiControls(text)
+
+  for (const char of normalizedText) {
+    if (RTL_SCRIPT_REGEX.test(char)) {
+      return 'rtl'
+    }
+
+    if (LTR_SCRIPT_REGEX.test(char)) {
+      return 'ltr'
+    }
+  }
+
+  return 'ltr'
+}


### PR DESCRIPTION
## Summary
- add robust per-message RTL/LTR direction detection using first-strong script heuristics
- render mixed-language chat content with direction-aware alignment (RTL/LTR per line/block)
- improve markdown bidi handling (lists, headings, paragraphs, blockquotes)
- keep code/table blocks explicitly LTR
- add explicit RTL font switching and apply **Vazirmatn** for RTL content while preserving existing LTR typography

## Font support (explicit)
- introduce `Vazirmatn` via `next/font/google` in `src/app/layout.tsx`
- add `.font-vazirmatn` utility in `src/app/globals.css`
- apply `font-vazirmatn` to detected RTL message/markdown content
- ensure markdown typography classes inherit container font so `font-inter` does not override Vazirmatn in RTL blocks

## Why
Agent responses can contain RTL languages (e.g., Persian/Arabic/Hebrew) and mixed RTL/LTR content. This change makes rendering correct and readable for RTL users without forcing the entire app to RTL.

## Notes
- scope is message/content rendering only (no global app layout mirroring)
- chat input now uses `dir="auto"` for better multilingual typing
