### PR TITLE
feat: add Workflow mode to chat with AgentOS workflows

### DIFF
--- a/src/api/os.ts
+++ b/src/api/os.ts
@@ -2,7 +2,12 @@ import { toast } from 'sonner'
 
 import { APIRoutes } from './routes'
 
-import { AgentDetails, Sessions, TeamDetails } from '@/types/os'
+import {
+  AgentDetails,
+  Sessions,
+  TeamDetails,
+  WorkflowDetails
+} from '@/types/os'
 
 // Helper function to create headers with optional auth token
 const createHeaders = (authToken?: string): HeadersInit => {
@@ -52,7 +57,7 @@ export const getStatusAPI = async (
 
 export const getAllSessionsAPI = async (
   base: string,
-  type: 'agent' | 'team',
+  type: 'agent' | 'team' | 'workflow',
   componentId: string,
   dbId: string,
   authToken?: string
@@ -82,7 +87,7 @@ export const getAllSessionsAPI = async (
 
 export const getSessionAPI = async (
   base: string,
-  type: 'agent' | 'team',
+  type: 'agent' | 'team' | 'workflow',
   sessionId: string,
   dbId?: string,
   authToken?: string
@@ -165,4 +170,31 @@ export const deleteTeamSessionAPI = async (
     throw new Error(`Failed to delete team session: ${response.statusText}`)
   }
   return response
+}
+
+export const getWorkflowsAPI = async (
+  endpoint: string,
+  authToken?: string
+): Promise<WorkflowDetails[]> => {
+  const url = APIRoutes.GetWorkflows(endpoint)
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: createHeaders(authToken)
+    })
+    if (!response.ok) {
+      toast.error(`Failed to fetch workflows: ${response.statusText}`)
+      return []
+    }
+    const data = await response.json()
+    return (Array.isArray(data) ? data : []).map((w: { id: string; name?: string; description?: string; db_id?: string }) => ({
+      id: w.id,
+      name: w.name ?? w.id,
+      description: w.description,
+      db_id: w.db_id
+    }))
+  } catch {
+    toast.error('Error fetching workflows')
+    return []
+  }
 }

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -13,5 +13,9 @@ export const APIRoutes = {
   TeamRun: (agentOSUrl: string, teamId: string) =>
     `${agentOSUrl}/teams/${teamId}/runs`,
   DeleteTeamSession: (agentOSUrl: string, teamId: string, sessionId: string) =>
-    `${agentOSUrl}/v1//teams/${teamId}/sessions/${sessionId}`
+    `${agentOSUrl}/v1//teams/${teamId}/sessions/${sessionId}`,
+
+  GetWorkflows: (agentOSUrl: string) => `${agentOSUrl}/workflows`,
+  WorkflowRun: (agentOSUrl: string, workflowId: string) =>
+    `${agentOSUrl}/workflows/${workflowId}/runs`
 }

--- a/src/components/chat/Sidebar/EntitySelector.tsx
+++ b/src/components/chat/Sidebar/EntitySelector.tsx
@@ -15,7 +15,8 @@ import { useEffect } from 'react'
 import useChatActions from '@/hooks/useChatActions'
 
 export function EntitySelector() {
-  const { mode, agents, teams, setMessages, setSelectedModel } = useStore()
+  const { mode, agents, teams, workflows, setMessages, setSelectedModel } =
+    useStore()
 
   const { focusChatInput } = useChatActions()
   const [agentId, setAgentId] = useQueryState('agent', {
@@ -26,21 +27,44 @@ export function EntitySelector() {
     parse: (value) => value || undefined,
     history: 'push'
   })
+  const [workflowId, setWorkflowId] = useQueryState('workflow', {
+    parse: (value) => value || undefined,
+    history: 'push'
+  })
   const [, setSessionId] = useQueryState('session')
 
-  const currentEntities = mode === 'team' ? teams : agents
-  const currentValue = mode === 'team' ? teamId : agentId
-  const placeholder = mode === 'team' ? 'Select Team' : 'Select Agent'
+  const currentEntities =
+    mode === 'team'
+      ? teams
+      : mode === 'workflow'
+        ? workflows
+        : agents
+  const currentValue =
+    mode === 'team' ? teamId : mode === 'workflow' ? workflowId : agentId
+  const placeholder =
+    mode === 'team'
+      ? 'Select Team'
+      : mode === 'workflow'
+        ? 'Select Workflow'
+        : 'Select Agent'
 
   useEffect(() => {
     if (currentValue && currentEntities.length > 0) {
       const entity = currentEntities.find((item) => item.id === currentValue)
       if (entity) {
-        setSelectedModel(entity.model?.model || '')
+        setSelectedModel(
+          'model' in entity && entity.model?.model
+            ? entity.model.model
+            : 'Workflow'
+        )
         if (mode === 'team') {
           setTeamId(entity.id)
+        } else if (mode === 'workflow') {
+          setWorkflowId(entity.id)
         }
-        if (entity.model?.model) {
+        if ('model' in entity && entity.model?.model) {
+          focusChatInput()
+        } else if (mode === 'workflow') {
           focusChatInput()
         }
       }
@@ -52,20 +76,35 @@ export function EntitySelector() {
     const newValue = value === currentValue ? null : value
     const selectedEntity = currentEntities.find((item) => item.id === newValue)
 
-    setSelectedModel(selectedEntity?.model?.provider || '')
+    setSelectedModel(
+      selectedEntity && 'model' in selectedEntity && selectedEntity.model?.provider
+        ? selectedEntity.model.provider
+        : mode === 'workflow'
+          ? 'Workflow'
+          : ''
+    )
 
     if (mode === 'team') {
       setTeamId(newValue)
       setAgentId(null)
+      setWorkflowId(null)
+    } else if (mode === 'workflow') {
+      setWorkflowId(newValue)
+      setAgentId(null)
+      setTeamId(null)
     } else {
       setAgentId(newValue)
       setTeamId(null)
+      setWorkflowId(null)
     }
 
     setMessages([])
     setSessionId(null)
 
-    if (selectedEntity?.model?.provider) {
+    if (
+      (selectedEntity && 'model' in selectedEntity && selectedEntity.model?.provider) ||
+      mode === 'workflow'
+    ) {
       focusChatInput()
     }
   }

--- a/src/components/chat/Sidebar/ModeSelector.tsx
+++ b/src/components/chat/Sidebar/ModeSelector.tsx
@@ -18,14 +18,16 @@ export function ModeSelector() {
   const [, setAgentId] = useQueryState('agent')
   const [, setTeamId] = useQueryState('team')
   const [, setSessionId] = useQueryState('session')
+  const [, setWorkflowId] = useQueryState('workflow')
 
-  const handleModeChange = (newMode: 'agent' | 'team') => {
+  const handleModeChange = (newMode: 'agent' | 'team' | 'workflow') => {
     if (newMode === mode) return
 
     setMode(newMode)
 
     setAgentId(null)
     setTeamId(null)
+    setWorkflowId(null)
     setSelectedModel('')
     setMessages([])
     setSessionId(null)
@@ -37,7 +39,9 @@ export function ModeSelector() {
       <Select
         defaultValue={mode}
         value={mode}
-        onValueChange={(value) => handleModeChange(value as 'agent' | 'team')}
+        onValueChange={(value) =>
+          handleModeChange(value as 'agent' | 'team' | 'workflow')
+        }
       >
         <SelectTrigger className="h-9 w-full rounded-xl border border-primary/15 bg-primaryAccent text-xs font-medium uppercase">
           <SelectValue />
@@ -49,6 +53,10 @@ export function ModeSelector() {
 
           <SelectItem value="team" className="cursor-pointer">
             <div className="text-xs font-medium uppercase">Team</div>
+          </SelectItem>
+
+          <SelectItem value="workflow" className="cursor-pointer">
+            <div className="text-xs font-medium uppercase">Workflow</div>
           </SelectItem>
         </SelectContent>
       </Select>

--- a/src/components/chat/Sidebar/Sessions/SessionItem.tsx
+++ b/src/components/chat/Sidebar/Sessions/SessionItem.tsx
@@ -25,6 +25,7 @@ const SessionItem = ({
 }: SessionItemProps) => {
   const [agentId] = useQueryState('agent')
   const [teamId] = useQueryState('team')
+  const [workflowId] = useQueryState('workflow')
   const [dbId] = useQueryState('db_id')
   const [, setSessionId] = useQueryState('session')
   const authToken = useStore((state) => state.authToken)
@@ -35,7 +36,7 @@ const SessionItem = ({
   const { clearChat } = useChatActions()
 
   const handleGetSession = async () => {
-    if (!(agentId || teamId || dbId)) return
+    if (!(agentId || teamId || workflowId || dbId)) return
 
     onSessionClick()
     await getSession(
@@ -43,6 +44,7 @@ const SessionItem = ({
         entityType: mode,
         agentId,
         teamId,
+        workflowId,
         dbId: dbId ?? ''
       },
       session_id
@@ -51,7 +53,7 @@ const SessionItem = ({
   }
 
   const handleDeleteSession = async () => {
-    if (!(agentId || teamId || dbId)) return
+    if (!(agentId || teamId || workflowId || dbId)) return
     setIsDeleting(true)
     try {
       const response = await deleteSessionAPI(

--- a/src/components/chat/Sidebar/Sessions/Sessions.tsx
+++ b/src/components/chat/Sidebar/Sessions/Sessions.tsx
@@ -37,6 +37,7 @@ const Sessions = () => {
     history: 'push'
   })
   const [teamId] = useQueryState('team')
+  const [workflowId] = useQueryState('workflow')
   const [sessionId] = useQueryState('session')
   const [dbId] = useQueryState('db_id')
 
@@ -81,16 +82,19 @@ const Sessions = () => {
   }, [])
 
   useEffect(() => {
-    if (hydrated && sessionId && selectedEndpoint && (agentId || teamId)) {
-      const entityType = agentId ? 'agent' : 'team'
-      getSession({ entityType, agentId, teamId, dbId }, sessionId)
+    if (hydrated && sessionId && selectedEndpoint && (agentId || teamId || workflowId)) {
+      const entityType = agentId ? 'agent' : teamId ? 'team' : 'workflow'
+      getSession(
+        { entityType, agentId, teamId, workflowId, dbId },
+        sessionId
+      )
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hydrated, sessionId, selectedEndpoint, agentId, teamId, dbId])
+  }, [hydrated, sessionId, selectedEndpoint, agentId, teamId, workflowId, dbId])
 
   useEffect(() => {
     if (!selectedEndpoint || isEndpointLoading) return
-    if (!(agentId || teamId || dbId)) {
+    if (!(agentId || teamId || workflowId || dbId)) {
       setSessionsData([])
       return
     }
@@ -99,6 +103,7 @@ const Sessions = () => {
       entityType: mode,
       agentId,
       teamId,
+      workflowId,
       dbId
     })
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -106,6 +111,7 @@ const Sessions = () => {
     selectedEndpoint,
     agentId,
     teamId,
+    workflowId,
     mode,
     isEndpointLoading,
     getSessions,

--- a/src/components/chat/Sidebar/Sidebar.tsx
+++ b/src/components/chat/Sidebar/Sidebar.tsx
@@ -222,6 +222,7 @@ const Sidebar = ({
   const [isMounted, setIsMounted] = useState(false)
   const [agentId] = useQueryState('agent')
   const [teamId] = useQueryState('team')
+  const [workflowId] = useQueryState('workflow')
 
   useEffect(() => {
     setIsMounted(true)
@@ -296,7 +297,7 @@ const Sidebar = ({
                     <>
                       <ModeSelector />
                       <EntitySelector />
-                      {selectedModel && (agentId || teamId) && (
+                      {selectedModel && (agentId || teamId || workflowId) && (
                         <ModelDisplay model={selectedModel} />
                       )}
                     </>

--- a/src/hooks/useAIStreamHandler.tsx
+++ b/src/hooks/useAIStreamHandler.tsx
@@ -16,6 +16,7 @@ const useAIChatStreamHandler = () => {
   const { addMessage, focusChatInput } = useChatActions()
   const [agentId] = useQueryState('agent')
   const [teamId] = useQueryState('team')
+  const [workflowId] = useQueryState('workflow')
   const [sessionId, setSessionId] = useQueryState('session')
   const selectedEndpoint = useStore((state) => state.selectedEndpoint)
   const authToken = useStore((state) => state.authToken)
@@ -146,6 +147,8 @@ const useAIChatStreamHandler = () => {
 
         if (mode === 'team' && teamId) {
           RunUrl = APIRoutes.TeamRun(endpointUrl, teamId)
+        } else if (mode === 'workflow' && workflowId) {
+          RunUrl = APIRoutes.WorkflowRun(endpointUrl, workflowId)
         } else if (mode === 'agent' && agentId) {
           RunUrl = APIRoutes.AgentRun(endpointUrl).replace(
             '{agent_id}',
@@ -155,7 +158,9 @@ const useAIChatStreamHandler = () => {
 
         if (!RunUrl) {
           updateMessagesWithErrorState()
-          setStreamingErrorMessage('Please select an agent or team first.')
+          setStreamingErrorMessage(
+            'Please select an agent, team or workflow first.'
+          )
           setIsStreaming(false)
           return
         }
@@ -436,6 +441,7 @@ const useAIChatStreamHandler = () => {
       streamResponse,
       agentId,
       teamId,
+      workflowId,
       mode,
       setStreamingErrorMessage,
       setIsStreaming,

--- a/src/hooks/useChatActions.ts
+++ b/src/hooks/useChatActions.ts
@@ -3,8 +3,8 @@ import { toast } from 'sonner'
 
 import { useStore } from '../store'
 
-import { AgentDetails, TeamDetails, type ChatMessage } from '@/types/os'
-import { getAgentsAPI, getStatusAPI, getTeamsAPI } from '@/api/os'
+import { AgentDetails, TeamDetails, WorkflowDetails, type ChatMessage } from '@/types/os'
+import { getAgentsAPI, getStatusAPI, getTeamsAPI, getWorkflowsAPI } from '@/api/os'
 import { useQueryState } from 'nuqs'
 
 const useChatActions = () => {
@@ -17,10 +17,12 @@ const useChatActions = () => {
   const setIsEndpointLoading = useStore((state) => state.setIsEndpointLoading)
   const setAgents = useStore((state) => state.setAgents)
   const setTeams = useStore((state) => state.setTeams)
+  const setWorkflows = useStore((state) => state.setWorkflows)
   const setSelectedModel = useStore((state) => state.setSelectedModel)
   const setMode = useStore((state) => state.setMode)
   const [agentId, setAgentId] = useQueryState('agent')
   const [teamId, setTeamId] = useQueryState('team')
+  const [workflowId, setWorkflowId] = useQueryState('workflow')
   const [, setDbId] = useQueryState('db_id')
 
   const getStatus = useCallback(async () => {
@@ -52,6 +54,16 @@ const useChatActions = () => {
     }
   }, [selectedEndpoint, authToken])
 
+  const getWorkflows = useCallback(async () => {
+    try {
+      const workflows = await getWorkflowsAPI(selectedEndpoint, authToken)
+      return workflows
+    } catch {
+      toast.error('Error fetching workflows')
+      return []
+    }
+  }, [selectedEndpoint, authToken])
+
   const clearChat = useCallback(() => {
     setMessages([])
     setSessionId(null)
@@ -78,12 +90,14 @@ const useChatActions = () => {
       const status = await getStatus()
       let agents: AgentDetails[] = []
       let teams: TeamDetails[] = []
+      let workflows: WorkflowDetails[] = []
       if (status === 200) {
         setIsEndpointActive(true)
         teams = await getTeams()
         agents = await getAgents()
+        workflows = await getWorkflows()
 
-        if (!agentId && !teamId) {
+        if (!agentId && !teamId && !workflowId) {
           const currentMode = useStore.getState().mode
 
           if (currentMode === 'team' && teams.length > 0) {
@@ -92,18 +106,29 @@ const useChatActions = () => {
             setSelectedModel(firstTeam.model?.provider || '')
             setDbId(firstTeam.db_id || '')
             setAgentId(null)
+            setWorkflowId(null)
             setTeams(teams)
+          } else if (currentMode === 'workflow' && workflows.length > 0) {
+            const firstWorkflow = workflows[0]
+            setWorkflowId(firstWorkflow.id)
+            setSelectedModel('Workflow')
+            setDbId(firstWorkflow.db_id || '')
+            setAgentId(null)
+            setTeamId(null)
+            setWorkflows(workflows)
           } else if (currentMode === 'agent' && agents.length > 0) {
             const firstAgent = agents[0]
             setMode('agent')
             setAgentId(firstAgent.id)
             setSelectedModel(firstAgent.model?.model || '')
             setDbId(firstAgent.db_id || '')
+            setWorkflowId(null)
             setAgents(agents)
           }
         } else {
           setAgents(agents)
           setTeams(teams)
+          setWorkflows(workflows)
           if (agentId) {
             const agent = agents.find((a) => a.id === agentId)
             if (agent) {
@@ -111,6 +136,7 @@ const useChatActions = () => {
               setSelectedModel(agent.model?.model || '')
               setDbId(agent.db_id || '')
               setTeamId(null)
+              setWorkflowId(null)
             } else if (agents.length > 0) {
               const firstAgent = agents[0]
               setMode('agent')
@@ -118,6 +144,7 @@ const useChatActions = () => {
               setSelectedModel(firstAgent.model?.model || '')
               setDbId(firstAgent.db_id || '')
               setTeamId(null)
+              setWorkflowId(null)
             }
           } else if (teamId) {
             const team = teams.find((t) => t.id === teamId)
@@ -126,6 +153,7 @@ const useChatActions = () => {
               setSelectedModel(team.model?.provider || '')
               setDbId(team.db_id || '')
               setAgentId(null)
+              setWorkflowId(null)
             } else if (teams.length > 0) {
               const firstTeam = teams[0]
               setMode('team')
@@ -133,6 +161,24 @@ const useChatActions = () => {
               setSelectedModel(firstTeam.model?.provider || '')
               setDbId(firstTeam.db_id || '')
               setAgentId(null)
+              setWorkflowId(null)
+            }
+          } else if (workflowId) {
+            const workflow = workflows.find((w) => w.id === workflowId)
+            if (workflow) {
+              setMode('workflow')
+              setSelectedModel('Workflow')
+              setDbId(workflow.db_id || '')
+              setAgentId(null)
+              setTeamId(null)
+            } else if (workflows.length > 0) {
+              const firstWorkflow = workflows[0]
+              setMode('workflow')
+              setWorkflowId(firstWorkflow.id)
+              setSelectedModel('Workflow')
+              setDbId(firstWorkflow.db_id || '')
+              setAgentId(null)
+              setTeamId(null)
             }
           }
         }
@@ -142,8 +188,9 @@ const useChatActions = () => {
         setSelectedModel('')
         setAgentId(null)
         setTeamId(null)
+        setWorkflowId(null)
       }
-      return { agents, teams }
+      return { agents, teams, workflows }
     } catch (error) {
       console.error('Error initializing :', error)
       setIsEndpointActive(false)
@@ -151,8 +198,10 @@ const useChatActions = () => {
       setSelectedModel('')
       setAgentId(null)
       setTeamId(null)
+      setWorkflowId(null)
       setAgents([])
       setTeams([])
+      setWorkflows([])
     } finally {
       setIsEndpointLoading(false)
     }
@@ -160,25 +209,30 @@ const useChatActions = () => {
     getStatus,
     getAgents,
     getTeams,
+    getWorkflows,
     setIsEndpointActive,
     setIsEndpointLoading,
     setAgents,
     setTeams,
+    setWorkflows,
     setAgentId,
     setSelectedModel,
     setMode,
     setTeamId,
+    setWorkflowId,
     setDbId,
     agentId,
-    teamId
+    teamId,
+    workflowId
   ])
 
   return {
     clearChat,
     addMessage,
     getAgents,
-    focusChatInput,
     getTeams,
+    getWorkflows,
+    focusChatInput,
     initialize
   }
 }

--- a/src/hooks/useSessionLoader.tsx
+++ b/src/hooks/useSessionLoader.tsx
@@ -18,9 +18,10 @@ interface SessionResponse {
 }
 
 interface LoaderArgs {
-  entityType: 'agent' | 'team' | null
+  entityType: 'agent' | 'team' | 'workflow' | null
   agentId?: string | null
   teamId?: string | null
+  workflowId?: string | null
   dbId: string | null
 }
 
@@ -32,8 +33,13 @@ const useSessionLoader = () => {
   const setSessionsData = useStore((state) => state.setSessionsData)
 
   const getSessions = useCallback(
-    async ({ entityType, agentId, teamId, dbId }: LoaderArgs) => {
-      const selectedId = entityType === 'agent' ? agentId : teamId
+    async ({ entityType, agentId, teamId, workflowId, dbId }: LoaderArgs) => {
+      const selectedId =
+        entityType === 'agent'
+          ? agentId
+          : entityType === 'team'
+            ? teamId
+            : workflowId
       if (!selectedEndpoint || !entityType || !selectedId || !dbId) return
 
       try {
@@ -59,10 +65,15 @@ const useSessionLoader = () => {
 
   const getSession = useCallback(
     async (
-      { entityType, agentId, teamId, dbId }: LoaderArgs,
+      { entityType, agentId, teamId, workflowId, dbId }: LoaderArgs,
       sessionId: string
     ) => {
-      const selectedId = entityType === 'agent' ? agentId : teamId
+      const selectedId =
+        entityType === 'agent'
+          ? agentId
+          : entityType === 'team'
+            ? teamId
+            : workflowId
       if (
         !selectedEndpoint ||
         !sessionId ||

--- a/src/store.ts
+++ b/src/store.ts
@@ -5,6 +5,7 @@ import {
   AgentDetails,
   SessionEntry,
   TeamDetails,
+  WorkflowDetails,
   type ChatMessage
 } from '@/types/os'
 
@@ -42,10 +43,12 @@ interface Store {
   setAgents: (agents: AgentDetails[]) => void
   teams: TeamDetails[]
   setTeams: (teams: TeamDetails[]) => void
+  workflows: WorkflowDetails[]
+  setWorkflows: (workflows: WorkflowDetails[]) => void
   selectedModel: string
   setSelectedModel: (model: string) => void
-  mode: 'agent' | 'team'
-  setMode: (mode: 'agent' | 'team') => void
+  mode: 'agent' | 'team' | 'workflow'
+  setMode: (mode: 'agent' | 'team' | 'workflow') => void
   sessionsData: SessionEntry[] | null
   setSessionsData: (
     sessionsData:
@@ -90,6 +93,8 @@ export const useStore = create<Store>()(
       setAgents: (agents) => set({ agents }),
       teams: [],
       setTeams: (teams) => set({ teams }),
+      workflows: [],
+      setWorkflows: (workflows) => set({ workflows }),
       selectedModel: '',
       setSelectedModel: (selectedModel) => set(() => ({ selectedModel })),
       mode: 'agent',

--- a/src/types/os.ts
+++ b/src/types/os.ts
@@ -228,6 +228,13 @@ export interface TeamDetails {
   model?: Model
 }
 
+export interface WorkflowDetails {
+  id: string
+  name?: string
+  description?: string
+  db_id?: string
+}
+
 export interface ImageData {
   revised_prompt: string
   url: string


### PR DESCRIPTION
Adds a third mode "Workflow" in the sidebar (next to Agent / Team). You pick a workflow from the list and chat with it like with agents/teams — same behaviour as in the cloud UI.

**Changes:**
- ModeSelector: new "Workflow" option, selection in URL as `?workflow=...`
- API: `GET /workflows` and `POST /workflows/{workflow_id}/runs`; sessions use `type=workflow` and `component_id`
- Store + hooks: workflows state, fetch on init, stream handler hits workflow run endpoint when mode is workflow
- Sessions sidebar: workflow sessions listed/loaded via `entityType: 'workflow'`

Streaming uses the same events as agent/team (`RunStarted`, `RunContent`, `RunCompleted`). Tested against an AgentOS instance with workflows (e.g. investment-team); select Workflow, pick one, send a message and check streaming + session persistence.