### PR TITLE
fix: append streamed content deltas instead of replacing previous content

### DIFF
--- a/src/hooks/useAIStreamHandler.tsx
+++ b/src/hooks/useAIStreamHandler.tsx
@@ -137,7 +137,6 @@ const useAIChatStreamHandler = () => {
         created_at: Math.floor(Date.now() / 1000) + 1
       })
 
-      let lastContent = ''
       let newSessionId = sessionId
       try {
         const endpointUrl = constructEndpointUrl(selectedEndpoint)
@@ -230,9 +229,7 @@ const useAIChatStreamHandler = () => {
                   lastMessage.role === 'agent' &&
                   typeof chunk.content === 'string'
                 ) {
-                  const uniqueContent = chunk.content.replace(lastContent, '')
-                  lastMessage.content += uniqueContent
-                  lastContent = chunk.content
+                  lastMessage.content += chunk.content
 
                   // Handle tool calls streaming
                   lastMessage.tool_calls = processChunkToolCalls(
@@ -273,7 +270,6 @@ const useAIChatStreamHandler = () => {
                   const jsonBlock = getJsonMarkdown(chunk?.content)
 
                   lastMessage.content += jsonBlock
-                  lastContent = jsonBlock
                 } else if (
                   chunk.response_audio?.transcript &&
                   typeof chunk.response_audio?.transcript === 'string'


### PR DESCRIPTION
## Problem

agno streams `RunContent` as **token-level deltas** — `RunContentEvent` is documented as "Main event for each delta of the RunOutput", and providers emit per-chunk delta text (e.g. the Anthropic provider yields `RunContentEvent(content=text_delta)`).

The stream handler instead treated `chunk.content` as **cumulative**:

```ts
const uniqueContent = chunk.content.replace(lastContent, '')
lastMessage.content += uniqueContent
lastContent = chunk.content
```

`String.replace(lastContent, '')` removes the first occurrence of the *previous* delta from the *current* delta. Whenever a delta repeats text from the previous one — common with repeated words or tokens — the current delta is mangled.

## Reproduction

Running the exact reducer over a delta stream (agno deltas, left→right):

| streamed deltas | rendered (before) | expected |
|---|---|---|
| `['na', ' na', ' na']` | `"na "` | `"na na na"` |
| `['go', ' go']` | `"go "` | `"go go"` |
| `['the', ' the']` | `"the "` | `"the the"` |
| `['Hello', ' world']` | `"Hello world"` | `"Hello world"` (unaffected) |

## Fix

Append each delta directly and drop the unused `lastContent` tracking:

```ts
lastMessage.content += chunk.content
```

Non-repeating content is unchanged; repeated words/tokens are no longer dropped. The JSON-content branch already appended its block, so only its dead `lastContent` assignment is removed.